### PR TITLE
Fix Capes Not Appearing

### DIFF
--- a/src/main/java/org/geysermc/extension/thirdpartycosmetics/Utils.java
+++ b/src/main/java/org/geysermc/extension/thirdpartycosmetics/Utils.java
@@ -26,6 +26,9 @@
 package org.geysermc.extension.thirdpartycosmetics;
 
 import java.awt.image.BufferedImage;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +61,43 @@ public class Utils {
             return future.get(timeoutInSeconds, TimeUnit.SECONDS);
         } catch (Exception ignored) {}
         return defaultValue;
+    }
+
+    private static BufferedImage scale(BufferedImage bufferedImage, int newWidth, int newHeight) {
+        BufferedImage resized = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = resized.createGraphics();
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2.drawImage(bufferedImage, 0, 0, newWidth, newHeight, null);
+        g2.dispose();
+        bufferedImage.flush();
+        return resized;
+    }
+
+    /**
+     * Resize a BufferedImage that is expected to be a cape
+     *
+     * @param image The BufferedImage to resize
+     * @return The converted BufferedImage
+     */
+    public static BufferedImage resizeCape(BufferedImage image) throws IOException {
+        if (image.getWidth() > 64 || image.getHeight() > 32) {
+            // Prevent weirdly-scaled capes from being cut off
+            BufferedImage newImage = new BufferedImage(128, 64, BufferedImage.TYPE_INT_ARGB);
+            Graphics g = newImage.createGraphics();
+            g.drawImage(image, 0, 0, image.getWidth(), image.getHeight(), null);
+            g.dispose();
+            image.flush();
+            image = scale(newImage, 64, 32);
+        } else if (image.getWidth() < 64 || image.getHeight() < 32) {
+            // Bedrock doesn't like smaller-sized capes, either.
+            BufferedImage newImage = new BufferedImage(64, 32, BufferedImage.TYPE_INT_ARGB);
+            Graphics g = newImage.createGraphics();
+            g.drawImage(image, 0, 0, image.getWidth(), image.getHeight(), null);
+            g.dispose();
+            image.flush();
+            image = newImage;
+        }
+        return image;
     }
 
     /**

--- a/src/main/java/org/geysermc/extension/thirdpartycosmetics/capes/CapeFetcher.java
+++ b/src/main/java/org/geysermc/extension/thirdpartycosmetics/capes/CapeFetcher.java
@@ -29,6 +29,7 @@ import org.geysermc.extension.thirdpartycosmetics.Utils;
 import org.geysermc.geyser.api.skin.Cape;
 
 import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -68,7 +69,14 @@ public class CapeFetcher {
     private static Cape supplyCape(String capeUrl) {
         byte[] cape = new byte[0];
         try {
-            cape = Utils.bufferedImageToImageData(ImageIO.read(new URL(capeUrl)));
+            BufferedImage originalImage = ImageIO.read(new URL(capeUrl));
+            if(originalImage.getWidth() != 64 || originalImage.getHeight() != 32){
+                BufferedImage resizedImage = Utils.resizeCape(originalImage);
+                cape = Utils.bufferedImageToImageData(resizedImage);
+            }
+            else{
+                cape = Utils.bufferedImageToImageData(originalImage);
+            }
         } catch (Exception ignored) {
         } // just ignore I guess
 


### PR DESCRIPTION
This PR fixes a lost implementation where capes would be re-scaled to fit Bedrock. Bedrock expects capes to be 64 pixels wide and 32 pixels tall. If this requirement is not met, then capes will not appear on the client. This feature was [implemented previously in Geyser](https://github.com/GeyserMC/Geyser/blob/master/core/src/main/java/org/geysermc/geyser/skin/SkinProvider.java#L441), but appeared to have not been ported to this extension. This PR fixes that!

This PR will automatically re-scale and fit capes if they are not already 64 pixels by 32 pixels, making it so bedrock clients will have no issues loading capes.

> [!NOTE]
>
> + All of the code committed to Utils was pulled directly from GeyserMC as to not cause any re-implementation conflicts.
> + This PR does not cache images like Geyser used to do. This may be useful in the future

Related Issues:

+ #8 
+ #9 (duplicate)

Thanks much! 🧡 